### PR TITLE
[FIX] Removes risky unnecessary JS

### DIFF
--- a/src/mkdocs.yml
+++ b/src/mkdocs.yml
@@ -28,7 +28,6 @@ extra_css:
 - stylesheets/extra.css
 extra_javascript:
 - javascripts/config.js
-- https://polyfill.io/v3/polyfill.min.js?features=es6
 - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 plugins:
 - mkdocstrings:


### PR DESCRIPTION
## Security patch for the published doc (no package release or version bump)

This is the removal of a patch to support internet explorer 6 (replaced 11 years ago). The site is known for security issues and the patch can sometimes redirect doc browsing to polyfill.io prompting for credentials.